### PR TITLE
Fix wrong provider command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This providers expects a `validDate` parameter in HTTP date format, and then ret
 Start the provider in a separate terminal:
 
 ```
-$ node provider/provider.js
+$ node provider/providerService.js
 Provider Service listening on http://localhost:9123
 ```
 


### PR DESCRIPTION
Provider listener is invoked in `providerService.js`, running just the `provider.js` does nothing.